### PR TITLE
7 redo layouts

### DIFF
--- a/main.py
+++ b/main.py
@@ -233,6 +233,11 @@ if __name__ == '__main__':
         st.session_state['show_img_twice'] = False
     if 'show_navigator' not in st.session_state:
         st.session_state['show_navigator'] = False
+    if KEY not in st.session_state:
+        st.session_state[KEY] = ''
+    if VALUE not in st.session_state:
+        st.session_state[VALUE] = ''
+
 
     # This is the image that will be annotated
     guid, fnum = indexed_images[st.session_state['image_index']]
@@ -261,8 +266,11 @@ if __name__ == '__main__':
         if st.session_state['skip_reason'] == skip_reason_otherkey:
             st.session_state['skip_reason'] = st.text_area('Reason for skipping', key='skip_reason_free')
         # Skip frame for which key-value annotations are not applicable
-        st.button("Skip Frame", on_click=cycle_images, args=(indexed_images, guid, fnum, 'skip'))
+        st.button("Skip Frame", on_click=cycle_images, args=(indexed_images, guid, fnum, 'skip'), 
                   disabled='skip_reason' not in st.session_state or st.session_state['skip_reason'] is None or st.session_state['skip_reason'] == '')
+        st.button("Save and proceed to next Frame", use_container_width=True, key='cont_top',
+                  disabled=len(st.session_state[VALUE]) + len(st.session_state['annotations']) == 0,
+                  on_click=cycle_images, args=(indexed_images, guid, fnum, 'next'))
     ##############################
     # Add annotation
     ##############################
@@ -313,7 +321,8 @@ if __name__ == '__main__':
         st.write(st.session_state['annotations'])
     edit_col, next_col = st.columns(2)
     with next_col:
-        st.button("Save and proceed to next Frame", use_container_width=True, disabled=len(st.session_state['annotations']) == 0,
+        st.button("Save and proceed to next Frame", use_container_width=True, key='cont_bottom',
+                  disabled=len(st.session_state[VALUE]) + len(st.session_state['annotations']) == 0,
                   on_click=cycle_images, args=(indexed_images, guid, fnum, 'next'))
     with edit_col:
         ##############################

--- a/main.py
+++ b/main.py
@@ -230,25 +230,6 @@ if __name__ == '__main__':
     results = load_results(guid, fnum)
     image_name = get_image_id(guid, fnum)
     ocr = OCR(sample_img, results)
-    with st.expander('Data Navigator', expanded=st.session_state['show_navigator']):
-        #############################
-        # Image Navigation
-        #############################
-        sel_video_col, sel_frame_col, go_btn_col = st.columns((2, 2, 1))
-        with sel_video_col:
-            ops = list(guids.keys())
-            idx = ops.index(guid)
-            nav_guid_picker = st.selectbox('Select video', options=ops, index=idx,
-                                           format_func=lambda x: f'{x} ({get_progress_guid(x, string=True)})')
-        with sel_frame_col:
-            ops = guids[nav_guid_picker]
-            idx = ops.index(fnum) if nav_guid_picker == guid else 0
-            nav_fnum_picker = st.selectbox('Select frame', options=guids[nav_guid_picker], index=idx,
-                                           format_func=lambda x: f'{x} {"✅" if get_progress_guid_fnum(nav_guid_picker, x) else "❌"}')
-        with go_btn_col:
-            st.button('Go', help='Go to selected image', on_click=lambda: st.session_state.update(
-                {'image_index': revindex_images[(nav_guid_picker, nav_fnum_picker)], 'annotations': None}))
-
     st.subheader(f'Current image: `{guid}` {fnum}')
     img_col, skip_col = st.columns((7, 1))
     with img_col:
@@ -330,3 +311,24 @@ if __name__ == '__main__':
                 ks = st.multiselect(f'Select {KEY} to delete', options=opts,
                                  format_func=lambda x: f'"{x}"' if x else "EMPTY KEY")
                 st.button(f"Delete {KEY}-{VALUE} Pair", on_click=delete_pairs, args=(ks,))
+    # with st.expander('Data Navigator', expanded=st.session_state['show_navigator']):
+    st.divider()
+    with st.container():
+        #############################
+        # Image Navigation
+        #############################
+        sel_video_col, sel_frame_col, go_btn_col = st.columns((2, 2, 1))
+        with sel_video_col:
+            ops = list(guids.keys())
+            idx = ops.index(guid)
+            nav_guid_picker = st.selectbox('Select video', options=ops, index=idx,
+                                           format_func=lambda x: f'{x} ({get_progress_guid(x, string=True)})')
+        with sel_frame_col:
+            ops = guids[nav_guid_picker]
+            idx = ops.index(fnum) if nav_guid_picker == guid else 0
+            nav_fnum_picker = st.selectbox('Select frame', options=guids[nav_guid_picker], index=idx,
+                                           format_func=lambda x: f'{x} {"✅" if get_progress_guid_fnum(nav_guid_picker, x) else "❌"}')
+        with go_btn_col:
+            st.button('Go', help='Go to selected image', on_click=lambda: st.session_state.update(
+                {'image_index': revindex_images[(nav_guid_picker, nav_fnum_picker)], 'annotations': None}))
+

--- a/main.py
+++ b/main.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
     results = load_results(guid, fnum)
     image_name = get_image_id(guid, fnum)
     ocr = OCR(sample_img, results)
-    st.subheader(f'Current image: `{guid}` {fnum}')
+    st.subheader(f'Current image: `{guid}` {fnum} ([AAPB reading room](https://americanarchive.org/catalog/{guid.replace("cpb-aacip-", "cpb-aacip_")}))')
     img_col, skip_col = st.columns((7, 1))
     with img_col:
         ##############################


### PR DESCRIPTION
fixes #7. 

PR to rearrange GUI components so that, major components are now vertically ordered in 
1. `image viewer` + `mark as dupe` + `mark as not annotatable`
2. `add a pair`
3. individual boxes and `to_key` / `to_value` buttons
4. `current annotations` + `image viewer` (again, hidden by default)
5. `edit` or `save` (removing "continuing", see #6 )
6. `data navigator`

